### PR TITLE
Add keepalived label to interface.

### DIFF
--- a/templates/keepalived_instance.erb
+++ b/templates/keepalived_instance.erb
@@ -8,8 +8,14 @@ vrrp_instance <%=  @name %> {
   interface <%= @interface %>
 
   virtual_ipaddress {
-    <% @virtual_ips.each do |vip| -%>
-    <%= vip %>
+    <% if @virtual_ips.is_a? Hash then %>
+        <% @virtual_ips.each do |vip, label| -%>
+            <%= vip -%> label <%= @interface -%>:<%= label %>
+        <% end %>
+    <% else %>
+        <% @virtual_ips.each do |vip| -%>
+            <%= vip -%>
+        <% end %>
     <% end %>
   }
 


### PR DESCRIPTION
Useful e.g. if this interface is also controlled by DHCP - then
you can configure DHCP hooks to save/restore keepalived's IP around
DHCP-triggered IP changes.
