### PR TITLE
Allow different name & virtual_router_id

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -3,13 +3,14 @@ define keepalived::instance (
   $virtual_ips,
   $state,
   $priority,
-  $track_script  = [],
-  $notify        = undef,
-  $notify_master = undef,
-  $notify_backup = undef,
-  $notify_fault  = undef,
-  $smtp_alert    = false,
-  $advert_int    = '1',
+  $track_script          = [],
+  $notify                = undef,
+  $notify_master         = undef,
+  $notify_backup         = undef,
+  $notify_fault          = undef,
+  $smtp_alert            = false,
+  $advert_int            = '1',
+  $virtual_router_id     = $name,
 ) {
 
   include keepalived::variables

--- a/templates/keepalived_instance.erb
+++ b/templates/keepalived_instance.erb
@@ -1,5 +1,5 @@
 vrrp_instance <%= @name %> {
-  virtual_router_id <%= @name %>
+  virtual_router_id <%= @virtual_router_id %>
 
   # Advert interval
   advert_int <%= @advert_int %>


### PR DESCRIPTION
As virtual_router_id should be numeric but instance name doesn't
necessarily have to be it is good to allow them to be different.
Keep the name being the default however.
