### PR TITLE
Fix global_config.erb for Puppet 4 parser

### DIFF
--- a/templates/global_config.erb
+++ b/templates/global_config.erb
@@ -1,6 +1,6 @@
 global_defs {
   notification_email {
-  <% notification_email_to.each do |email| -%>
+  <% @notification_email_to.each do |email| -%>
   <%= email %>
   <% end -%>}
   notification_email_from <%= @notification_email_from %>


### PR DESCRIPTION
Puppet 4 parser requires to add "@" before all variables in a template.