### PR TITLE
Config :: Add 'dynamic_interfaces' support

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -4,7 +4,8 @@ class keepalived::config (
   $smtp_server,
   $smtp_connect_timeout,
   $router_id,
-  $static_ipaddress
+  $static_ipaddress,
+  $dynamic_interfaces,
 ) {
 
   concat { $keepalived::variables::keepalived_conf:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,6 +22,12 @@
 # [*router_id*] = $::hostname
 #   The router_id identifies us on the network.
 #
+# [*dynamic_interfaces*] = false
+#   Allow configuration to include interfaces that don't exist at startup.
+#   This allows keepalived to work with interfaces that may be deleted and
+#   restored. It also allows virtual and static routes and rules on VMAC
+#   interfaces.
+#
 # === Variables
 #
 # [*$keepalived::variables::keepalived_conf*]
@@ -46,6 +52,7 @@ class keepalived (
   $smtp_connect_timeout    = '30',
   $router_id               = $::hostname,
   $static_ipaddress        = [],
+  $dynamic_interfaces      = false,
 ) {
 
   Class[ "${module_name}::install" ] ->
@@ -61,6 +68,7 @@ class keepalived (
     smtp_connect_timeout    => $keepalived::smtp_connect_timeout,
     router_id               => $keepalived::router_id,
     static_ipaddress        => $keepalived::static_ipaddress,
+    dynamic_interfaces      => $keepalived::dynamic_interfaces,
   }
   include "${module_name}::service"
 

--- a/templates/global_config.erb
+++ b/templates/global_config.erb
@@ -7,6 +7,9 @@ global_defs {
   smtp_server <%= @smtp_server %>
   smtp_connect_timeout <%= @smtp_connect_timeout %>
   router_id <%= @router_id %>
+<% if @dynamic_interfaces -%>
+  dynamic_interfaces
+<% end -%>
 }
 
 static_ipaddress {


### PR DESCRIPTION
Recent keepalived added the option to enable support
for dynamic interfaces which allow configuration to
include interfaces that don't exist at startup. This
allows keepalived to work with interfaces that may
be deleted and restored and also allows virtual and
static routes and rules on VMAC interfaces.